### PR TITLE
Bug fix: Too short array (4-byte) caused crash on writing (5-byte).

### DIFF
--- a/MedtronicESP/BLEInterface.cpp
+++ b/MedtronicESP/BLEInterface.cpp
@@ -35,10 +35,10 @@ void BLEInterface::sendBattery(uint8_t battery) {
 void BLEInterface::sendBolus(float bolus) {
     std::string message = bolusESP;
     message += equals;
-    char charBolus[4];
+    char charBolus[5];
     dtostrf(bolus, 4, 2, charBolus);  
     message += charBolus;
-    message += '\0';
+    //message += '\0';
     while(!sendMessage(message)) {
         #ifdef doDebug
             Serial.println("Failed to send message, retrying...");
@@ -50,7 +50,7 @@ void BLEInterface::sendTemp(float basalRate, uint8_t duration) {
     std::string message = tempESP;
     message += equals;
     if (basalRate != 0) {
-        char charBasal[4];
+        char charBasal[5];
         dtostrf(basalRate, 4, 2, charBasal);  
         message += charBasal;  
         message += binder;


### PR DESCRIPTION
Bug caused crash when writing bolus or temp to outbound message array. Bug was caused by the outbound message array being too short to occupy the float or integer value. Solution: Made array larger to match size of value.